### PR TITLE
Fix serializer typo and trailing commas

### DIFF
--- a/horario/serializers.py
+++ b/horario/serializers.py
@@ -96,11 +96,13 @@ class AusenciaCreateSerializer(serializers.ModelSerializer):
     
     def validate_horario_fecha(self, horario,fecha):
         ausencia = Ausencia.objects.filter(horario=horario, fecha=fecha).first()
-        if(not ausencia is None):
-            if(not self.instance is None and ausencia.id == self.instance,id):
+        if not ausencia is None:
+            if not self.instance is None and ausencia.id == self.instance.id:
                 pass
             else:
-                raise serializers.ValidationError("Ya existe una ausencia registrada para este horario y fecha.")
+                raise serializers.ValidationError(
+                    "Ya existe una ausencia registrada para este horario y fecha."
+                )
         return horario
     
     def create(self, validated_data):
@@ -121,10 +123,10 @@ class AusenciaCreateSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError({"fecha": "Formato de fecha inválido. Usa YYYY-MM-DD."})
 
 
-        instance.profesor=validated_data["profesor"],
-        instance.fecha=validated_data["fecha"],
-        instance.motivo=validated_data["motivo"],
-        instance.horario=validated_data["horario"]
+        instance.profesor = validated_data["profesor"]
+        instance.fecha = validated_data["fecha"]
+        instance.motivo = validated_data["motivo"]
+        instance.horario = validated_data["horario"]
         instance.save()
         return instance
     


### PR DESCRIPTION
## Summary
- fix equality check in `validate_horario_fecha`
- clean up assignments in `AusenciaCreateSerializer.update`
- add final newline

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684181aaf9ec8324a1a0940cbbf6a600